### PR TITLE
Manifest V3 migration

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,7 +136,7 @@ The manifest is a simple JSON file that tells the browser about your web applica
 // manifest.json
 
 {
-  "manifest_version": 2,
+  "manifest_version": 3,
   "name": "My first Chrome Extension",
   "description": "Chrome extension workshop for Le Wagon Tokyo",
   "author": "Your name",
@@ -148,7 +148,7 @@ The manifest is a simple JSON file that tells the browser about your web applica
   "background": {
     // ...
   },
-  "browser_action": {
+  "action": {
     // ...
   },
   "icons": {
@@ -264,7 +264,7 @@ Add this to your manifest.json file.
 {
   // ...
 
-  "browser_action": {
+  "action": {
     "default_popup": "popup.html",
     "default_title": "My first Chrome Extension"
   },

--- a/manifest.json
+++ b/manifest.json
@@ -1,5 +1,5 @@
 {
-  //   "manifest_version": 2,
+  //   "manifest_version": 3,
   //   "name": "My first Chrome Extension",
   //   "description": "Chrome extension workshop for Le Wagon Tokyo",
   //   "author": "Your name",


### PR DESCRIPTION
Hi, when I took the workshop earlier today, I noticed that this Chrome extension comes with an error:

> Manifest version 2 is deprecated, and support will be removed in 2023. See https://developer.chrome.com/blog/mv2-transition/ for more details.

Related posts announced that version 2 will no longer be supported soon. So I tried to update the configuration to version 3.